### PR TITLE
:bug:[BUG] FAR(2차원 리스트) 복사할 때 참조되던 문제 해결

### DIFF
--- a/졸작 이후의 과제/distinguishing_people_by_ppg_signals.py
+++ b/졸작 이후의 과제/distinguishing_people_by_ppg_signals.py
@@ -1003,6 +1003,7 @@ class DistinguishingPeopleByPpgSignals:
         :return:
         """
         FAR = []
+        # FAR_origin = []
 
         print("FAR")
         # print(tuple(unique_num_Y_dec))
@@ -1038,8 +1039,16 @@ class DistinguishingPeopleByPpgSignals:
             del unique_num_dec[i]
             del unique_num_Y_dec[i]
 
-        # print(FAR)
-        FAR_origin = FAR
+        print(FAR)
+        # FAR_origin = FAR[:]
+        # FAR_origin = FAR.copy()
+        # FAR_origin = tuple(FAR)
+
+        FAR_origin = []
+
+        for i, data in enumerate(FAR):
+            FAR_origin.append((tuple(data)))
+        FAR_origin = tuple(FAR_origin)
 
         unique_num_count = [0] * max
 
@@ -1053,7 +1062,7 @@ class DistinguishingPeopleByPpgSignals:
                     FAR[i][j] = round(FAR[i][j], 2)
                 except ZeroDivisionError:
                     pass
-                    FAR[i][j] = 0
+                    # FAR[i][j] = 0
 
         print(FAR)
 


### PR DESCRIPTION
2차원 리스트의 하위 리스트를 생각하지 않고 얕은 복사(.copy)를 사용하여 발생한 문제.
이 문제를 deepcopy 메서드를 사용하지 않고 튜플의 성질을 이용하여 해결함.

아래 블로그 참고.
https://blex.me/@mildsalmon/%EB%8B%A4%EC%B0%A8%EC%9B%90-%EB%A6%AC%EC%8A%A4%ED%8A%B8-%EB%A6%AC%EC%8A%A4%ED%8A%B8-%EB%B3%B5%EC%82%AC